### PR TITLE
seekTo fix

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1572,7 +1572,7 @@ pub const Writer = struct {
             .mode = w.mode,
             .pos = w.pos,
             .interface = Reader.initInterface(w.interface.buffer),
-            .seek_err = w.seek_err,
+            .seek_err = null,
         };
     }
 

--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1527,10 +1527,7 @@ pub const Writer = struct {
         Unexpected,
     };
 
-    pub const SeekError = File.SeekError || error{
-        // Seeking had to flush buffered data, which failed.
-        WriteFailed,
-    };
+    pub const SeekError = File.SeekError || std.Io.Writer.Error;
 
     /// Number of slices to store on the stack, when trying to send as many byte
     /// vectors through the underlying write calls as possible.


### PR DESCRIPTION
Fixes xxx.

The `std.fs.File.Writer`'s `seekTo` now flushes to ensure buffered data is written appropriately.

A consequence is that `seekTo` now must also be able to respond with any error that occurred during the flush. In the style of `std.fs.File.Reader` I introduced `Writer.SeekError` which keeps the original `File.SeekError` but also includes `std.Io.Writer.Error`. 

Expanding the possible errors introduced an issue with `moveToReader`. The possible errors for the `seek_err` of a writer is no longer compatible with the reader. The writer set includes additional members not present in the reader set. There would seem to be three possible solutions.
1. Do not expand the possible seek errors for the writer and have a flush failure return an existing member, say `UnexpectedError`. 
2. Perform a filtering on the writer seek error inside of `moveToReader` to reduce the error so that it's a valid member of the reader's seek error set.
3. Reset the error so that the reader's seek error starts null regardless of the writer's seek error. 

I decided to go with option 3. This because option 1 does not really feel appropriate since `UnexpectedError` should be reserved for something truly unexpected. Option 2 might be preferable but I lack the experience/knowledge of zig to do this error set filtering in a comptime compatible way. 
